### PR TITLE
FreeBSD support

### DIFF
--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -1378,7 +1378,7 @@ cmd_daemon(int argc, char **argv)
 		if (gQuit)
 			break;
 
-		auto got = ::poll(pfds.data(), pfds.size(), -1);
+		auto got = ::poll(pfds.data(), nfds_t(pfds.size()), -1);
 		if (got == -1) {
 			if (errno == EINTR) {
 				::fprintf(stderr, "interrupted\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -811,6 +811,7 @@ cmd_command(int argc, char **argv)
 }
 
 unsigned long kUISetBitIOC[EV_MAX] = {0};
+unsigned long kBitLength[EV_MAX] = {0};
 int
 main(int argc, char **argv)
 {
@@ -823,6 +824,14 @@ main(int argc, char **argv)
 	kUISetBitIOC[EV_SND] = UI_SET_SNDBIT;
 	kUISetBitIOC[EV_FF ] = UI_SET_FFBIT;
 	kUISetBitIOC[EV_SW ] = UI_SET_SWBIT;
+	kBitLength[EV_KEY] = NLONGS(KEY_CNT);
+	kBitLength[EV_REL] = NLONGS(REL_CNT);
+	kBitLength[EV_ABS] = NLONGS(ABS_CNT);
+	kBitLength[EV_MSC] = NLONGS(MSC_CNT);
+	kBitLength[EV_LED] = NLONGS(LED_CNT);
+	kBitLength[EV_SND] = NLONGS(SND_CNT);
+	kBitLength[EV_FF ] = NLONGS(FF_CNT );
+	kBitLength[EV_SW ] = NLONGS(SW_CNT );
 
 	if (argc < 2)
 		usage(stderr, EXIT_FAILURE);

--- a/src/main.h
+++ b/src/main.h
@@ -43,6 +43,9 @@
 
 #define Packed __attribute__((packed))
 
+#define LONG_BITS (sizeof(long) * 8)
+#define NLONGS(x) (((x) + LONG_BITS - 1) / LONG_BITS)
+
 using std::string;
 using std::move;
 template<typename T, typename Deleter = std::default_delete<T>>
@@ -54,6 +57,7 @@ int cmd_daemon(int argc, char **argv);
 // C++ doesn't have designated initializers so this is filled in main()
 extern bool gUse_UI_DEV_SETUP;
 extern unsigned long kUISetBitIOC[EV_MAX];
+extern unsigned long kBitLength[EV_MAX];
 
 // "Internal" input event, equal to the usual 64 bit struct input_event
 // because struct timeval varies between architectures

--- a/src/main.h
+++ b/src/main.h
@@ -27,7 +27,11 @@
 #include <errno.h>
 #include <linux/input.h>
 #include <linux/uinput.h>
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 
 #include <string>
 #include <utility>

--- a/src/main.h
+++ b/src/main.h
@@ -25,8 +25,12 @@
 #include <sys/uio.h>
 #include <fcntl.h>
 #include <errno.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
 #include <linux/input.h>
 #include <linux/uinput.h>
+#pragma clang diagnostic pop
 #if defined(__FreeBSD__)
 #include <sys/endian.h>
 #else

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -284,13 +284,12 @@ InDevice::writeNE2AddDevice(int fd, uint16_t id)
 		// Only transfer bits which matter:
 		if (!ev || !kUISetBitIOC[ev.index()])
 			continue;
-		entrybits.setBitCount(0xFFF);
-		auto bytes = ctl(EVIOCGBIT(ev.index(), entrybits.byte_size()),
-		                 entrybits.data(),
-		                 "failed to query bits for event type %zu",
-		                 ev.index());
-		auto count = bytes * 8;
+		auto count = kBitLength[ev.index()] * LONG_BITS;
 		entrybits.setBitCount(size_t(count));
+		ctl(EVIOCGBIT(ev.index(), entrybits.byte_size()),
+		    entrybits.data(),
+		    "failed to query bits for event type %zu",
+		    ev.index());
 		netbitcount = htobe16(uint16_t(count));
 		iov[1].iov_len = entrybits.byte_size();
 		len = ssize_t(iov[0].iov_len + iov[1].iov_len);


### PR DESCRIPTION
This is mostly header and warning stuff, but there's a bigger issue too — `ioctl` can only return zero or an error, and you were relying on `EVIOCGBIT` returning the size in bytes, so the size was always zero, and the device appeared as not supporting any keys/etc.

`libevdev` never did this, they calculate the size exactly before calling the ioctl. Let's do the same.