### PR TITLE
Support out-of-tree builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,11 @@ all: $(BINARY) $(MAN1PAGES)
 config.h:
 	./configure
 
-# the src/*.d files contain 'src/../config.h' for this:
-src/../config.h: config.h
-
 $(BINARY): $(OBJECTS)
 	$(CXX) $(LDFLAGS) -o $@ $(OBJECTS)
 
 .cpp.o:
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $< -MMD -MT $@ -MF $(@:.o=.d)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I. -c -o $@ $< -MMD -MT $@ -MF $(@:.o=.d)
 
 .SUFFIXES: .1 .rst
 .rst.1:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ DATAROOTDIR = $(PREFIX)/share
 MANDIR = $(DATAROOTDIR)/man
 MAN1DIR = $(MANDIR)/man1
 
+SOURCEDIR ?= .
+
 CPPFLAGS ?= -g
 CPPFLAGS += -Wall -Werror -Wno-unknown-pragmas
 CXX ?= clang++
@@ -46,6 +48,10 @@ all: $(BINARY) $(MAN1PAGES)
 config.h:
 	./configure
 
+Makefile: $(SOURCEDIR)/Makefile
+	cp $< $@
+	+$(MAKE) $(MAKECMDGOALS)
+
 $(BINARY): $(OBJECTS)
 	$(CXX) $(LDFLAGS) -o $@ $(OBJECTS)
 
@@ -75,6 +81,10 @@ distclean: clean
 clean:
 	rm -f src/*.o src/*.d doc/*.1
 
-$(OBJECTS): config.h
+$(CURDIR)/doc $(CURDIR)/src:
+	mkdir -p $@
+
+$(OBJECTS): Makefile config.h $(CURDIR)/src
+$(MAN1PAGES): $(CURDIR)/doc
 
 -include src/*.d

--- a/configure
+++ b/configure
@@ -54,6 +54,11 @@ done
 rm -f config.log
 exec 4>config.log
 
+absdirname()
+(cd `dirname $1`; pwd)
+
+SOURCEDIR=`absdirname $0`
+
 PREFIX="${PREFIX:-/usr/local}"
 BINDIR="${BINDIR:-${PREFIX}/bin}"
 DATAROOTDIR="${DATAROOTDIR:-${PREFIX}/share}"
@@ -150,5 +155,13 @@ MAN1DIR = ${MAN1DIR}
 ENABLE_DOC = ${ENABLE_DOC}
 RST2MAN = ${RST2MAN}
 CXX = ${CXX}
+SOURCEDIR = ${SOURCEDIR}
 EOF
 
+if [ "${SOURCEDIR}" != "${PWD}" ]; then
+	# Only use VPATH for out-of-tree builds; it can be problematic for some
+	# variants of `make` and users of these variants will be limited to in-tree
+	# builds only.
+	echo >>config.mak "VPATH = ${SOURCEDIR}"
+	cp "${SOURCEDIR}/Makefile" ./
+fi

--- a/src/main.h
+++ b/src/main.h
@@ -33,7 +33,7 @@
 
 using std::move;
 
-#include "../config.h"
+#include "config.h"
 #include "types.h"
 #include "iohandle.h"
 #include "socket.h"


### PR DESCRIPTION
Adds support for building in a directory separate from the source code tree:

```sh
mkdir /tmp/build
cd /tmp/build
${path_to_source}/configure
make
```

Also necessarily includes a commit fixing the issue requiring the following hack in *Makefile*:
 
```make
# the src/*.d files contain 'src/../config.h' for this:
src/../config.h: config.h
```