### PR TITLE
Manage writing to outputs and grabbing inputs separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Host side:
     device add mykbd /dev/input/by-id/usb-MyAwesomeKeyboard-event-kbd
 
     # Add toggle hotkey (on press, and ignore the release event)
-    hotkey add mykbd key:189:1 grab toggle; write toggle
+    hotkey add mykbd key:189:1 grab-devices toggle; write-events toggle
     hotkey add mykbd key:189:0 nop
 
     # Connect to the two devices via password-less ssh

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ Host side:
     device add mykbd /dev/input/by-id/usb-MyAwesomeKeyboard-event-kbd
 
     # Add toggle hotkey (on press, and ignore the release event)
-    hotkey add mykbd key:189:1 grab toggle
+    hotkey add mykbd key:189:1 grab toggle; write toggle
     hotkey add mykbd key:189:0 nop
 
     # Connect to the two devices via password-less ssh
     output add myremote exec:ssh user@other-host netevent create
-    # Cause grabbing to write to that output
+    # Select the output to write to
     use myremote
     ```
 

--- a/doc/netevent.rst
+++ b/doc/netevent.rst
@@ -120,9 +120,9 @@ DAEMON COMMANDS
         Executed on a ``use`` command or when an output device fails and a
         fallback is being activated.
     * ``write-changed``
-        Executed whenever the ``write`` command is used.
+        Executed whenever the ``write-events`` command is used.
     * ``grab-changed``
-        Executed whenever the ``grab`` command is used.
+        Executed whenever the ``grab-devices`` command is used.
     * ``device-lost``
         Executed whenever a device we are reading from disappears.
 
@@ -136,11 +136,15 @@ DAEMON COMMANDS
 ``nop``
     Nothing. Bind as hotkey to ignore an event and be explicit about it.
 
-``grab``\  *on*\ \|\ *off*\ \|\ *toggle*
+``grab-devices``\  *on*\ \|\ *off*\ \|\ *toggle*
     Set the grabbing state. Controls whether events are also fired locally.
 
-``write``\  *on*\ \|\ *off*\ \|\ *toggle*
+``write-events``\  *on*\ \|\ *off*\ \|\ *toggle*
     Set the writing state. Controls whether events are passed to the current output.
+
+``grab``\  *on*\ \|\ *off*\ \|\ *toggle*
+    Deprecated. This is the old command which has been superseeded by the pair
+    ``grab-devices`` and ``write-events``.
 
 ``use`` *OUTPUT*
     Set the current output.

--- a/doc/netevent.rst
+++ b/doc/netevent.rst
@@ -119,6 +119,8 @@ DAEMON COMMANDS
     * ``output-changed``
         Executed on a ``use`` command or when an output device fails and a
         fallback is being activated.
+    * ``write-changed``
+        Executed whenever the ``write`` command is used.
     * ``grab-changed``
         Executed whenever the ``grab`` command is used.
     * ``device-lost``
@@ -135,8 +137,10 @@ DAEMON COMMANDS
     Nothing. Bind as hotkey to ignore an event and be explicit about it.
 
 ``grab``\  *on*\ \|\ *off*\ \|\ *toggle*
-    Set the grabbing state. Currently this also controls whether events are
-    passed to the current output.
+    Set the grabbing state. Controls whether events are also fired locally.
+
+``write``\  *on*\ \|\ *off*\ \|\ *toggle*
+    Set the writing state. Controls whether events are passed to the current output.
 
 ``use`` *OUTPUT*
     Set the current output.
@@ -210,6 +214,9 @@ information to commands executed via an ``exec`` hotkey:
     This will be "1" if the daemon is currently grabbing, or "0" if it is not.
     Note that with multiple input devices, failure to grab an input device will
     cause this variable to be in an undefined state.
+
+* ``NETEVENT_WRITING``
+    This will be "1" if the daemon is currently writing, or "0" if it is not.
 
 BUGS
 ====

--- a/examples/laptop-and-vm-with-systemd/daemon.ne2
+++ b/examples/laptop-and-vm-with-systemd/daemon.ne2
@@ -24,9 +24,9 @@ device reset-name my-mouse
 device reset-name my-kbd
 
 # Add hotkeys to switch between host, laptop and the VM
-hotkey add my-kbd key:188:1 use vm0\; grab on; write on
+hotkey add my-kbd key:188:1 use vm0\; grab-devices on; write-events on
 hotkey add my-kbd key:188:0 nop
-hotkey add my-kbd key:187:1 use laptop\; grab on; write on
+hotkey add my-kbd key:187:1 use laptop\; grab-devices on; write-events on
 hotkey add my-kbd key:187:0 nop
-hotkey add my-kbd key:186:1 grab off; write off
+hotkey add my-kbd key:186:1 grab-devices off; write-events off
 hotkey add my-kbd key:186:0 nop

--- a/examples/laptop-and-vm-with-systemd/daemon.ne2
+++ b/examples/laptop-and-vm-with-systemd/daemon.ne2
@@ -24,9 +24,9 @@ device reset-name my-mouse
 device reset-name my-kbd
 
 # Add hotkeys to switch between host, laptop and the VM
-hotkey add my-kbd key:188:1 use vm0\; grab on
+hotkey add my-kbd key:188:1 use vm0\; grab on; write on
 hotkey add my-kbd key:188:0 nop
-hotkey add my-kbd key:187:1 use laptop\; grab on
+hotkey add my-kbd key:187:1 use laptop\; grab on; write on
 hotkey add my-kbd key:187:0 nop
-hotkey add my-kbd key:186:1 grab off
+hotkey add my-kbd key:186:1 grab off; write off
 hotkey add my-kbd key:186:0 nop

--- a/examples/simple.ne2
+++ b/examples/simple.ne2
@@ -3,10 +3,10 @@ device add my-mouse /dev/input/by-id/usb-MyCoolMouse-if01-event-mouse
 device add my-kbd /dev/input/by-id/usb-MyCoolKeyboard-event-kbd
 
 # Add toggle hotkey (on press, and ignore the release event)
-hotkey add my-kbd key:189:1 grab toggle
+hotkey add my-kbd key:189:1 grab toggle; write toggle
 hotkey add my-kbd key:189:0 nop
 
 # Add my usual output:
 output add laptop exec:ssh myuser@mylaptop netevent create
-# Cause grabbing to write to that output
+# Select the output to write to
 use laptop

--- a/examples/simple.ne2
+++ b/examples/simple.ne2
@@ -3,7 +3,7 @@ device add my-mouse /dev/input/by-id/usb-MyCoolMouse-if01-event-mouse
 device add my-kbd /dev/input/by-id/usb-MyCoolKeyboard-event-kbd
 
 # Add toggle hotkey (on press, and ignore the release event)
-hotkey add my-kbd key:189:1 grab toggle; write toggle
+hotkey add my-kbd key:189:1 grab-devices toggle; write-events toggle
 hotkey add my-kbd key:189:0 nop
 
 # Add my usual output:

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -24,6 +24,7 @@ using std::map;
 #define OUTPUT_CHANGED_EVENT "output-changed"
 #define DEVICE_LOST_EVENT    "device-lost"
 #define GRAB_CHANGED_EVENT   "grab-changed"
+#define WRITE_CHANGED_EVENT  "write-changed"
 
 static void
 usage_daemon [[noreturn]] (FILE *out, int exit_status)
@@ -97,6 +98,7 @@ static struct {
 	int fd = -1;
 	string name;
 }                            gCurrentOutput;
+static bool                  gWrite = false;
 static bool                  gGrab = false;
 static map<HotkeyDef, string> gHotkeys;
 static map<string, string>   gEventCommands;
@@ -397,6 +399,14 @@ tryHotkey(uint16_t device, uint16_t type, uint16_t code, int32_t value)
 }
 
 static void
+write(int clientfd, bool on)
+{
+	gWrite = on;
+	setEnvVar("NETEVENT_WRITING", on ? "1" : "0");
+	fireEvent(clientfd, WRITE_CHANGED_EVENT);
+}
+
+static void
 grab(int clientfd, bool on)
 {
 	gGrab = on;
@@ -411,6 +421,8 @@ lostCurrentOutput()
 {
 	gCurrentOutput.fd = -1;
 	gCurrentOutput.name = "<none>";
+	if (gWrite)
+		write(-1, false);
 	if (gGrab)
 		grab(-1, false);
 }
@@ -436,9 +448,7 @@ readFromDevice(InDevice *device, uint16_t id)
 	if (gCurrentOutput.fd == -1)
 		return;
 
-	// FIXME: currently we only write when grabbing; if anyone needs to b
-	// e able to control this separately... PR welcome
-	if (!gGrab)
+	if (!gWrite)
 		return;
 
 	pkt.cmd = htobe16(uint16_t(NE2Command::DeviceEvent));
@@ -677,6 +687,21 @@ addOutput(int clientfd, const vector<string>& args)
 	string cmd = join(' ', args.begin()+ssize_t(at), args.end());
 	addOutput(name, cmd.c_str(), skip_announce);
 	toClient(clientfd, "added output %s\n", name.c_str());
+}
+
+static void
+writeCommand(int clientfd, const char *state)
+{
+	if (parseBool(&gWrite, state)) {
+		// nothing
+	}
+	else if (!::strcasecmp(state, "toggle"))
+	{
+		gWrite = !gWrite;
+	}
+	else
+		throw MsgException("unknown write state: %s", state);
+	write(clientfd, gWrite);
 }
 
 static void
@@ -989,6 +1014,7 @@ clientCommand_Info(int clientfd, const vector<string>& args)
 	(void)args;
 
 	toClient(clientfd, "Grab: %s\n", gGrab ? "on" : "off");
+	toClient(clientfd, "Write: %s\n", gWrite ? "on" : "off");
 	toClient(clientfd, "Inputs: %zu\n", gInputs.size());
 	for (auto& i: gInputs) {
 		toClient(clientfd, "    %u: %s: %i\n",
@@ -1080,6 +1106,12 @@ clientCommand(int clientfd, const vector<string>& args)
 		clientCommand_Action(clientfd, args);
 	else if (args[0] == "info")
 		clientCommand_Info(clientfd, args);
+	else if (args[0] == "write") {
+		if (args.size() != 2)
+			throw Exception("'write' requires 1 parameter");
+		writeCommand(clientfd, args[1].c_str());
+		//toClient(clientfd, "write = %u\n", gWrite ? 1 : 0);
+	}
 	else if (args[0] == "grab") {
 		if (args.size() != 2)
 			throw Exception("'grab' requires 1 parameter");

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -1013,8 +1013,8 @@ clientCommand_Info(int clientfd, const vector<string>& args)
 {
 	(void)args;
 
-	toClient(clientfd, "Grab: %s\n", gGrab ? "on" : "off");
-	toClient(clientfd, "Write: %s\n", gWrite ? "on" : "off");
+	toClient(clientfd, "Grab-devices: %s\n", gGrab ? "on" : "off");
+	toClient(clientfd, "Write-events: %s\n", gWrite ? "on" : "off");
 	toClient(clientfd, "Inputs: %zu\n", gInputs.size());
 	for (auto& i: gInputs) {
 		toClient(clientfd, "    %u: %s: %i\n",
@@ -1106,17 +1106,24 @@ clientCommand(int clientfd, const vector<string>& args)
 		clientCommand_Action(clientfd, args);
 	else if (args[0] == "info")
 		clientCommand_Info(clientfd, args);
-	else if (args[0] == "write") {
+	else if (args[0] == "write-events") {
 		if (args.size() != 2)
-			throw Exception("'write' requires 1 parameter");
+			throw Exception("'write-events' requires 1 parameter");
 		writeCommand(clientfd, args[1].c_str());
-		//toClient(clientfd, "write = %u\n", gWrite ? 1 : 0);
+		//toClient(clientfd, "write-events = %u\n", gWrite ? 1 : 0);
+	}
+	else if (args[0] == "grab-devices") {
+		if (args.size() != 2)
+			throw Exception("'grab-devices' requires 1 parameter");
+		grabCommand(clientfd, args[1].c_str());
+		//toClient(clientfd, "grab-devices = %u\n", gGrab ? 1 : 0);
 	}
 	else if (args[0] == "grab") {
 		if (args.size() != 2)
 			throw Exception("'grab' requires 1 parameter");
 		grabCommand(clientfd, args[1].c_str());
-		//toClient(clientfd, "grab = %u\n", gGrab ? 1 : 0);
+		writeCommand(clientfd, args[1].c_str());
+		toClient(clientfd, "Warning: the command grab is deprecated, use grab-devices and write-events instead.\n");
 	}
 	else if (args[0] == "use") {
 		if (args.size() != 2)


### PR DESCRIPTION
For my use case I need to be able to fire events locally while also writing them
remotely. This PR allows this behaviour by decoupling the two actions.

Warning: this introduces a config breakage since the old `grab` is now a pair
`grab` and `write`. Unfortunately the old naming scheme did not make much sense
anymore.

This closes #20.

Signed-off-by: Salvatore Stella <salvatore.stella@univaq.it>
