### PR TITLE
Fix build with GCC 13

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include "socket.h"
+#include <cstdint>
 #include <sys/socket.h>
 #include <sys/un.h>
 


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes so some are no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/895142